### PR TITLE
Fix incorrect Pluscal translatation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *~
 
 build
+out
 .gradle
 gen/
 libs/*

--- a/src/main/java/pcal/PlusCalTranslator.java
+++ b/src/main/java/pcal/PlusCalTranslator.java
@@ -24,6 +24,7 @@ public class PlusCalTranslator {
 
         ToolIO.reset();
         ToolIO.setMode(ToolIO.TOOL);
+        PcalParams.resetParams();
 
         List<String> translated = trans.performTranslation(lines);
         if (translated != null) {

--- a/src/test/java/pcal/PlusCalTranslatorTest.java
+++ b/src/test/java/pcal/PlusCalTranslatorTest.java
@@ -1,0 +1,17 @@
+package pcal;
+
+import com.mayreh.intellij.plugin.tlaplus.TestUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PlusCalTranslatorTest {
+
+    @Test
+    public void translate() {
+        String input = TestUtils.resourceToString("pluscal/translate/test.tla");
+        String expected = TestUtils.resourceToString("pluscal/translate/test_expected.tla");
+        String actual = PlusCalTranslator.translate(input).getTranslated();
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/resources/pluscal/translate/test.tla
+++ b/src/test/resources/pluscal/translate/test.tla
@@ -1,0 +1,17 @@
+------------------------- MODULE test -------------------------
+EXTENDS Integers, Sequences
+
+(*--algorithm test
+variables
+    x = "",
+procedure foo() begin
+    Foo:
+        x := self;
+        return;
+end procedure;
+process baz = "One"
+begin Baz:
+    call foo()
+end process
+end algorithm;*)
+=============================================================================

--- a/src/test/resources/pluscal/translate/test_expected.tla
+++ b/src/test/resources/pluscal/translate/test_expected.tla
@@ -1,0 +1,58 @@
+------------------------- MODULE test -------------------------
+EXTENDS Integers, Sequences
+
+(*--algorithm test
+variables
+    x = "",
+procedure foo() begin
+    Foo:
+        x := self;
+        return;
+end procedure;
+process baz = "One"
+begin Baz:
+    call foo()
+end process
+end algorithm;*)
+\* BEGIN TRANSLATION (chksum(pcal) = "83c39aa4" /\ chksum(tla) = "a4310d13")
+VARIABLES x, pc, stack
+
+vars == << x, pc, stack >>
+
+ProcSet == {"One"}
+
+Init == (* Global variables *)
+        /\ x = ""
+        /\ stack = [self \in ProcSet |-> << >>]
+        /\ pc = [self \in ProcSet |-> "Baz"]
+
+Foo(self) == /\ pc[self] = "Foo"
+             /\ x' = self
+             /\ pc' = [pc EXCEPT ![self] = Head(stack[self]).pc]
+             /\ stack' = [stack EXCEPT ![self] = Tail(stack[self])]
+
+foo(self) == Foo(self)
+
+Baz == /\ pc["One"] = "Baz"
+       /\ stack' = [stack EXCEPT !["One"] = << [ procedure |->  "foo",
+                                                 pc        |->  "Done" ] >>
+                                             \o stack["One"]]
+       /\ pc' = [pc EXCEPT !["One"] = "Foo"]
+       /\ x' = x
+
+baz == Baz
+
+(* Allow infinite stuttering to prevent deadlock on termination. *)
+Terminating == /\ \A self \in ProcSet: pc[self] = "Done"
+               /\ UNCHANGED vars
+
+Next == baz
+           \/ (\E self \in ProcSet: foo(self))
+           \/ Terminating
+
+Spec == Init /\ [][Next]_vars
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION 
+=============================================================================


### PR DESCRIPTION
fixes https://github.com/ocadaruma/tlaplus-intellij-plugin/issues/9

## Motivation:
https://github.com/ocadaruma/tlaplus-intellij-plugin/issues/9
Incorrectness of translate result cannot be fixed off course by this PR, this may work with most inputs.


## Modifications:
Call `PcalParams.resetParams()` before translating PlusCal same as [Translator.java#L51].


[Translator.java#L51]: https://github.com/tlaplus/tlaplus/blob/v1.8.0/tlatools/org.lamport.tlatools/src/pcal/Translator.java#L51